### PR TITLE
Ensures readonly devices are not checkable

### DIFF
--- a/phantasy_apps/settings_manager/app.py
+++ b/phantasy_apps/settings_manager/app.py
@@ -28,13 +28,12 @@ from PyQt5.QtGui import (QColor, QFont, QFontDatabase, QFontMetrics, QIcon,
                          QDesktopServices, QDoubleValidator)
 from PyQt5.QtWidgets import (QCompleter, QCheckBox, QDialog, QLabel,
                              QMessageBox, QMenu, QAction, QWidgetAction,
-                             QToolButton, QPushButton, QSizePolicy, QShortcut,
+                             QToolButton, QSizePolicy, QShortcut,
                              QWidget, QProgressBar, QHBoxLayout, QLineEdit,
                              QLabel, QTabWidget, QGraphicsDropShadowEffect, QTreeView,
                              QScrollArea)
 
-from phantasy import (build_element, CaField, Settings)
-from phantasy_ui import (BaseAppForm, delayed_exec, get_open_filename,
+from phantasy_ui import (BaseAppForm, delayed_exec,
                          get_save_filename, printlog, milli_sleep)
 from phantasy_ui.widgets import (is_item_checked, BeamSpeciesDisplayWidget,
                                  DataAcquisitionThread as DAQT,
@@ -60,10 +59,7 @@ from .db_utils import insert_update_data, delete_data, get_attachments_cnt
 from .ui.ui_app import Ui_MainWindow
 from .ui.ui_query_tips import Ui_Form as QueryTipsForm
 from .conf import read_app_config
-from .utils import FMT
 from .utils import ELEMT_PX_MAP
-from .utils import TBTN_STY_REGULAR
-from .utils import TBTN_STY_GOLDEN
 from .utils import SettingsModel
 from .utils import pack_settings
 from .utils import COLUMN_NAMES
@@ -628,7 +624,6 @@ class SettingsManagerWindow(BaseAppForm, Ui_MainWindow):
         """
         printlog("Loading settings...")
         self.__flat_settings = flat_settings
-        self.__settings = settings
         self.__on_show_settings()
 
     def __on_show_settings(self):
@@ -756,7 +751,6 @@ class SettingsManagerWindow(BaseAppForm, Ui_MainWindow):
         self._elem_list = []  # element list for SettingsModel
         self._last_sts_dict = {}  # last device state dict
 
-        self.__settings = Settings()
         self.__flat_settings = None
 
         self._eval_scaling_factor = False  # not eval sf (hit enter)

--- a/phantasy_apps/settings_manager/config/settings_manager.toml
+++ b/phantasy_apps/settings_manager/config/settings_manager.toml
@@ -33,6 +33,8 @@ SCALABLE_FIELD_NAMES = ["I", "V", "AMP", "AMP1", "AMP2", "AMP3", "I_TC"]
 STRIPPER_POS = 224.90368452 # meter, carbon stripper location
 # for those write permission allowed per ACF but intended to be readonly.
 READONLY_DEVICE_LIST = [
+  'LS1_CA01:CAV1_D1127',
+
   'FE_ISRC1:BEAM',
   'FE_ISRC1:DRV_D0686',
   'FE_ISRC1:HVP_D0679',

--- a/phantasy_apps/settings_manager/utils.py
+++ b/phantasy_apps/settings_manager/utils.py
@@ -433,7 +433,9 @@ class SettingsModel(QStandardItemModel):
             row.append(item_tol)
 
             # writable
-            item_wa = QStandardItem('-')
+            item_wa = QStandardItem('False')
+            # by default: disable the item row --> non-checkable, until the data is refreshed
+            item_ename.setEnabled(False)
             item_wa.setEditable(False)
             row.append(item_wa)
 

--- a/phantasy_apps/settings_manager/utils.py
+++ b/phantasy_apps/settings_manager/utils.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import json
-import os
 import re
 import time
-import shutil
 import pandas as pd
 import numpy as np
 from collections import Counter
 from collections import OrderedDict
 from datetime import datetime
-from epics import get_pv
 from fnmatch import translate
 from functools import partial
 from numpy.testing import assert_almost_equal
@@ -22,7 +18,6 @@ from PyQt5.QtCore import QSortFilterProxyModel
 from PyQt5.QtCore import QPersistentModelIndex
 from PyQt5.QtCore import QItemSelectionModel
 from PyQt5.QtCore import QModelIndex
-from PyQt5.QtCore import QUrl
 from PyQt5.QtCore import QVariant
 from PyQt5.QtCore import Qt, QRect
 from PyQt5.QtCore import pyqtSignal
@@ -34,17 +29,12 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtGui import QStandardItem
 from PyQt5.QtGui import QStandardItemModel
-from PyQt5.QtWidgets import (QWidget, QHBoxLayout, QGraphicsDropShadowEffect, QLabel,)
 from PyQt5.QtWidgets import QStyle
 from PyQt5.QtWidgets import QStyledItemDelegate
-from PyQt5.QtWidgets import QToolButton
 from PyQt5.QtWidgets import QPushButton
-from PyQt5.QtWidgets import QSizePolicy
-from PyQt5.QtWidgets import QProgressBar
 from phantasy import get_settings_from_element_list
 from phantasy_ui.widgets import is_item_checked
 from phantasy_ui.widgets import BeamSpeciesDisplayWidget
-from phantasy_apps.utils import find_dconf
 from .data import SnapshotData
 from .config import ALL_SYM
 from phantasy_apps.msviz.mach_state import fetch_data


### PR DESCRIPTION
- Control the widget enabled/disabled state when loading a new snapshot
  - The `Check All/None/Invert` buttons will not be clickable before the new data refreshing is done
- Change the default writeable property for each row, from True to False
  - Prevents checking read-only items when the writable value retrieval returns from data refresher